### PR TITLE
request.request_uri was deprecated, using request.url

### DIFF
--- a/lib/paginate/helper.rb
+++ b/lib/paginate/helper.rb
@@ -25,7 +25,7 @@ module Paginate
         :collection => collection,
         :page => params[param_name],
         :param_name => param_name,
-        :fullpath => request.respond_to?(:fullpath) ? request.fullpath : request.request_uri
+        :fullpath => request.respond_to?(:fullpath) ? request.fullpath : request.url
       })
       options.merge!(:url => args.first) if args.any?
 


### PR DESCRIPTION
The request.request_uri has been deprecated in Rails 3.1, using request.url instead.
